### PR TITLE
[fix] typo for readme and get.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     - Extract knowledge from the html files crawled in step 1.
         - the extracted info is described in below #json_description.
 3. `python script/make_data.py`
-    - Make train/dev/test data from the json files extracted in step 2 based on `data/divide_data.tsv`.
+    - Make train/dev/test data from the json files extracted in step 2 based on `data/divided_data.tsv`.
         - The detail of the json files is below section.
 
 ### json description

--- a/get.sh
+++ b/get.sh
@@ -5,4 +5,4 @@ mkdir -p data/output
 
 bash crawl_article.sh
 bash scrape2jsonl.sh
-pythopn script/make_data.py data/json data/output data/divide_data.tsv
+python script/make_data.py data/json data/output data/divided_data.tsv


### PR DESCRIPTION
- get.sh: fix typo in last line
- README.md: divide_data.tsv -> divided_data.tsv